### PR TITLE
Fix API cache key encoding for server runtime

### DIFF
--- a/tests/api/api-cache.test.ts
+++ b/tests/api/api-cache.test.ts
@@ -1,0 +1,32 @@
+import { apiCache, stopApiCacheCleanup } from '@/lib/api-cache';
+
+describe('APICache on server runtime', () => {
+  beforeEach(() => {
+    apiCache.clear();
+  });
+
+  afterAll(() => {
+    stopApiCacheCleanup();
+  });
+
+  it('stores and retrieves cached responses without throwing in Node runtime', () => {
+    const data = { body: { ok: true }, status: 200 };
+
+    expect(() =>
+      apiCache.set('server-endpoint', data, { foo: 'bar' })
+    ).not.toThrow();
+
+    expect(apiCache.get('server-endpoint', { foo: 'bar' })).toEqual(data);
+  });
+
+  it('invalidates cached entries using decoded base64 keys', () => {
+    const data = { body: { ok: true }, status: 200 };
+
+    apiCache.set('/api/server-endpoint', data);
+    expect(apiCache.get('/api/server-endpoint')).toEqual(data);
+
+    expect(() => apiCache.invalidate('/api/server-endpoint')).not.toThrow();
+
+    expect(apiCache.get('/api/server-endpoint')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- encode API cache keys with Node-compatible base64 and update invalidation decoding
- track and expose the cleanup interval so it can be stopped in tests
- add an API cache test that runs under the Node environment to exercise the server runtime path

## Testing
- npm run test:api -- --runTestsByPath tests/api/api-cache.test.ts --coverage --coverageThreshold='{"global":{"branches":0,"functions":0,"lines":0,"statements":0}}'


------
https://chatgpt.com/codex/tasks/task_e_68cc6efa0e64832f9adf9916e9627229